### PR TITLE
fixed invoiceform when in mobile view to be clickable and also respect navbars

### DIFF
--- a/client/src/Components/InvoiceForm/InvoiceForm.css
+++ b/client/src/Components/InvoiceForm/InvoiceForm.css
@@ -51,6 +51,6 @@
         top: 190px;
         left: 17%;
         margin: 0 auto 75px;
-        z-index: -1;
+        z-index: 1;
     }
 }

--- a/client/src/Components/Navbar/Navbar.css
+++ b/client/src/Components/Navbar/Navbar.css
@@ -22,7 +22,7 @@
 
 /* unvisited link */
 .side-nav a:link {
-  color: #000000;
+  color: green;
 }
 
 /* visited link */

--- a/client/src/Components/Navbar/Navbar.css
+++ b/client/src/Components/Navbar/Navbar.css
@@ -88,5 +88,6 @@
       overflow: hidden;
       width: 100%;
       align-items: center;
+      z-index: 2;
   }
 }

--- a/client/src/Components/TopNav/TopNav.css
+++ b/client/src/Components/TopNav/TopNav.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-flow: row wrap;
   position: fixed;
+  z-index: 2;
 }
 
 .nav-container > * {


### PR DESCRIPTION
# Description
the previous CSS styling set the z-index of the InvoiceForm to -1, but that rendered it unusable

Fixes # (issue)
https://trello.com/c/1S5RbOWZ/93-invoiceform-isnt-clickable-on-tablet-mobile

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Change status
- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?
- [X] Make width less than 768px on /create_invoice and test scrolling and clicking forms

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
