### PR TITLE
Style disabled inputs to clearly indicate their status

### DIFF
--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -450,8 +450,8 @@ class InvoiceForm extends Component {
       return <Redirect to="/" />;
     }
 
-    
 
+    
     return (
       <div>
         <div className="form-container1">
@@ -753,7 +753,7 @@ class InvoiceForm extends Component {
                 onChange={this.handleInputChange}
               /> */}
             {/* Subtotal */}
-
+            
             <FormGroup row>
               <Label for="subtotal" sm={2}>
                 Subtotal 

--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -758,7 +758,7 @@ class InvoiceForm extends Component {
               <Label for="subtotal" sm={2}>
                 Subtotal 
               </Label>
-              <Col sm={2}>
+              <Col sm={3}>
                 {/* <Input
                   value={this.state.subtotal}
                   type="number"
@@ -830,7 +830,7 @@ class InvoiceForm extends Component {
               <Label for="shipping" sm={2}>
                 Shipping
               </Label>
-              <Col sm="2">
+              <Col sm="3">
                 <Input
                   value={this.state.shipping}
                   // value={accounting.formatMoney(this.state.shipping)}
@@ -850,7 +850,7 @@ class InvoiceForm extends Component {
               <Label for="total" sm={2}>
                 Total
               </Label>
-              <Col sm={2}>
+              <Col sm={3}>
                 <Input 
                   value={accounting.formatMoney(this.state.total)}
                   type="amount"
@@ -865,7 +865,7 @@ class InvoiceForm extends Component {
               <Label for="amount-paid" sm={2}>
                 Amount Paid:
               </Label>
-              <Col sm="2">
+              <Col sm="3">
                 <Input
                   value={this.state.amount_paid}
                   type="number"

--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -772,6 +772,7 @@ class InvoiceForm extends Component {
                   type="string"
                   name="subtotal"
                   id="subtotal"
+                  disabled
                 />
                 {/* <div>
                   {accounting.formatMoney(this.state.subtotal)}
@@ -855,6 +856,7 @@ class InvoiceForm extends Component {
                   type="amount"
                   name="total"
                   id="total"
+                  disabled
                 />
               </Col>
             </FormGroup>

--- a/client/src/Components/InvoiceForm/LineItems/LineItems.css
+++ b/client/src/Components/InvoiceForm/LineItems/LineItems.css
@@ -4,9 +4,9 @@
   margin-top: 10px;
 }
 
-.row_amount {
+/* .row_amount {
   display: flex;
   text-align: start;
   margin-top: 10px;
-}
+} */
 

--- a/client/src/Components/InvoiceForm/LineItems/LineItems.js
+++ b/client/src/Components/InvoiceForm/LineItems/LineItems.js
@@ -44,7 +44,17 @@ const LineItems = props => {
           }}
         />
       </td>
-      <td className="row_amount">${props.quantity * props.rate} </td>
+      <td className="row_amount"> 
+        <Input
+          value={accounting.formatMoney(props.quantity * props.rate)}
+          type="amount"
+          name="row_amount"
+          id="row_amount"
+          placeholder="0.00"
+          disabled
+        />
+      </td>
+      {/* <td className="row_amount">${props.quantity * props.rate} </td> */}
     </tr>
   );
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jspdf": "^1.4.1",
     "jspdf-autotable": "^2.3.5",
     "jwks-rsa": "^1.3.0",
+    "moment": "^2.22.2",
     "mongoose": "^5.3.10",
     "morgan": "^1.9.1",
     "multer": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,6 +2047,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 mongodb-core@3.1.7:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.7.tgz#fe61853a6a6acbd2046c91794e5325ecad85428a"


### PR DESCRIPTION
# Description
- Format Amount in line items using the accounting.formatMoney dependency and refactored it to be a disabled input using Reacstrap. Also formatted Subtotal and Total inputs to disabled to indicate their status which are auto-generated values. 

Fixes # (issue)
Trello: https://trello.com/c/OHGe33If/141-style-disabled-inputs-to-clearly-indicate-their-status

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Screenshot:

![image](https://user-images.githubusercontent.com/36179653/49759400-8c439e80-fcfc-11e8-9efe-01b09dca1000.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
