### PR TITLE
Move Due Date next to the Date, adjust other inputs for mobile view, and format Balance Due to show its disabled status.

### DIFF
--- a/client/src/Components/InvoiceForm/InvoiceForm.css
+++ b/client/src/Components/InvoiceForm/InvoiceForm.css
@@ -113,4 +113,51 @@
         margin: 0 auto 75px;
         z-index: 1;
     }
+
+    .date-label {
+        margin-top: 14px;
+        order: 2; 
+    }
+
+    .date {
+        order: 2;
+    }
+
+    .due-date-label {
+        order: 3
+    }
+
+    .due-date {
+        order: 3;
+        /* margin-top: 4px; */
+    }
+
+    .balance-due-label {
+        order: 4;
+    }
+
+    .balance-due {
+        display: flex; 
+        order: 4; 
+    }
+
+    .invoice-from-label {
+        order: 5;
+        margin-top: 10px; 
+    }
+
+    .invoice-from {
+        display: flex;
+        order: 5;
+        margin-top: 24px; 
+    }
+    
+    .invoice-to-label {
+        order: 6;
+    }
+
+    .invoice-to {
+        order: 6;
+        margin-top: 24px; 
+    }    
 }

--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -474,7 +474,7 @@ class InvoiceForm extends Component {
             </FormGroup>
             <img ref={this.logoRef} className="logo-img" />
             {/* Invoice Header Rigth Side */}
-            <FormGroup row classname="right-indent">
+            <FormGroup row className="invoice-number">
               <Label for="invoice_number" sm={2}>
                 Invoice Number
               </Label>
@@ -488,10 +488,10 @@ class InvoiceForm extends Component {
                   onChange={this.handleInputChange}
                 />
               </Col>
-              <Label for="date" sm={2}>
+              <Label for="date" sm={2} className="date-label">
                 Date
               </Label>
-              <Col sm={4}>
+              <Col sm={4} className="date">
                 <Input
                   value={this.state.date}
                   type="date"
@@ -504,8 +504,8 @@ class InvoiceForm extends Component {
             </FormGroup>
             {/* Invoice Customer Company Details */}
             <FormGroup row>
-              <Label for="company_name" sm={2} hidden>Invoice From</Label>
-              <Col sm={6}>
+              <Label for="company_name" sm={2} hidden className="invoice-from-label">Invoice From</Label>
+              <Col sm={6} className="invoice-from">
                 <Input
                   value={this.state.company_name}
                   type="text"
@@ -515,10 +515,10 @@ class InvoiceForm extends Component {
                   onChange={this.handleInputChange}
                 />
               </Col>
-              <Label for="due_date" sm={2}>
+              <Label for="due_date" sm={2} className="due-date-label">
                 Due Date
               </Label>
-              <Col sm={4}>
+              <Col sm={4} className="due-date">
                 <Input
                   value={this.state.due_date}
                   type="date"
@@ -530,8 +530,8 @@ class InvoiceForm extends Component {
               </Col>
             </FormGroup>
             <FormGroup row>
-              <Label for="invoiceTo" sm={2}hidden>Invoice To</Label>
-              <Col sm={6}>
+              <Label for="invoiceTo" sm={2}hidden className="invoice=to-label">Invoice To</Label>
+              <Col sm={6} className="invoice-to">
                 <Input
                   value={this.state.invoiceTo}
                   type="text"
@@ -541,10 +541,10 @@ class InvoiceForm extends Component {
                   onChange={this.handleInputChange}
                 />
               </Col>
-              <Label for="balance_due" sm={2}>
+              <Label for="balance_due" sm={2} className="balance-due-label">
                 Balance Due
               </Label>
-              <Col sm={4}>
+              <Col sm={4} className="balance-due">
                 <Input
                   value={accounting.formatMoney(this.state.balance_due)}
                   type="text"
@@ -556,8 +556,8 @@ class InvoiceForm extends Component {
             </FormGroup>
             {/* Address, State, Zip */}
             <FormGroup>
-              <Label for="address" hidden>Address</Label>
-              <Input
+              <Label for="address" hidden className="address-label">Address</Label>
+              <Input className="address"
                 value={this.state.address}
                 type="text"
                 name="address"
@@ -569,8 +569,8 @@ class InvoiceForm extends Component {
             <Row form>
               <Col md={2}>
                 <FormGroup>
-                  <Label for="zipcode" hidden>Zip</Label>
-                  <Input
+                  <Label for="zipcode" hidden className="zip-label">Zip</Label>
+                  <Input className="zip"
                     value={this.state.zipcode}
                     type="text"
                     name="zipcode"
@@ -582,8 +582,8 @@ class InvoiceForm extends Component {
               </Col>
               <Col md={6}>
                 <FormGroup>
-                  <Label for="city" hidden>City</Label>
-                  <Input
+                  <Label for="city" hidden className="city-label">City</Label>
+                  <Input className="city"
                     value={this.state.city}
                     type="text"
                     name="city"
@@ -595,8 +595,8 @@ class InvoiceForm extends Component {
               </Col>
               <Col md={4}>
                 <FormGroup>
-                  <Label for="state" hidden>State</Label>
-                  <Input
+                  <Label for="state" hidden className="state-label">State</Label>
+                  <Input className="state"
                     value={this.state.state}
                     type="text"
                     name="state"

--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -550,6 +550,7 @@ class InvoiceForm extends Component {
                   type="text"
                   name="balance_due"
                   id="balance_due"
+                  disabled
                 />
               </Col>
 


### PR DESCRIPTION
# Description
- Moved Due Date next to the Date and adjusted the other inputs for mobile view.
- Format Balance Due to show its disabled status.

Fixes # (issue)
Trello: https://trello.com/c/0n0fHXhD/155-move-due-date-next-to-the-date-adjust-other-inputs-for-mobile-view-and-format-balance-due-to-show-its-disabled-status

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Screenshot: 
![image](https://user-images.githubusercontent.com/36179653/49808645-ffe6b980-fd97-11e8-80e4-8c3e075a1684.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
