### PR TITLE
charges a credit for downloading pdf if not unlimited

### DIFF
--- a/api/routes/invoices.js
+++ b/api/routes/invoices.js
@@ -84,7 +84,7 @@ router.post("/", upload.single("logo"), (req, res) => {
     row.rate = Number(row.rate);
   });
 
-  const logo = null;
+  let logo = null;
 
   if (req.file) {
     const ext = req.file.originalname.split(".")[1];

--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -34,7 +34,6 @@ class InvoiceForm extends Component {
     this.logo = null;
     this.logoRaw = null;
     this.invalidForm = false;
-    this.edit = false;
     this.logoRef = React.createRef();
   }
   state = {
@@ -76,7 +75,7 @@ class InvoiceForm extends Component {
 
     if (path === "/invoices/:id") {
       const params = this.props.params;
-      this.edit = true;
+      this.setState({ edit: true })
       const invoice = (await axios.get(
         process.env.REACT_APP_NEW_INVOICE + `/${params.id}`
       )).data;
@@ -282,8 +281,12 @@ class InvoiceForm extends Component {
     pdf.text(this.state.notes, 75, 745);
     pdf.text("Terms -", 30, 760);
     pdf.text(this.state.terms, 75, 760);
-
-    pdf.save(`Invoice${this.state.invoice_number}`);
+    if (!this.state.edit) {
+      pdf.save(`Invoice${this.state.invoice_number}`);
+      this.handleSubmit(event);
+    } else {
+      pdf.save(`Invoice${this.state.invoice_number}`);
+    }    
   };
 
   calculateSubtotal() {
@@ -517,7 +520,7 @@ class InvoiceForm extends Component {
                 onChange={this.handleImageChange}
                 disabled={this.state.disabled}
               />
-              {this.edit ? (
+              {this.state.edit ? (
                 <FormText color="muted">
                   Browse file to change your company logo.
                 </FormText>
@@ -860,7 +863,7 @@ class InvoiceForm extends Component {
               <div className="form-error">{error}</div>
             ))}
 
-            {this.edit ? (
+            {this.state.edit ? (
               <Button
                 type="generate"
                 className="update-button"


### PR DESCRIPTION
# Description

Downloading a PDF while edit is false charges a credit if user is not unlimited and redirects to invoice list

Fixes # https://trello.com/c/mmY71dcl/165-dont-allow-download-pdf-if-credit-has-not-been-taken
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
