### PR TITLE
disabled fields for updating invoice form that shouldn't be changed

### DIFF
--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -75,7 +75,7 @@ class InvoiceForm extends Component {
 
     if (path === "/invoices/:id") {
       const params = this.props.params;
-      this.state.edit = true;
+      this.setState({edit: true});
       const invoice = (await axios.get(
         process.env.REACT_APP_NEW_INVOICE + `/${params.id}`
       )).data;
@@ -85,16 +85,16 @@ class InvoiceForm extends Component {
           invoice[item].forEach(lineItem => {
             copyArray.push(lineItem);
           });
-          this.setState({ lineItems: copyArray });
+          // this.setState({ lineItems: copyArray });
         } else if (item === "date" || item === "due_date")
-          this.setState({ [item]: invoice[item].substring(0, 10) });
-        else this.setState({ [item]: invoice[item] });
+          // this.setState({ [item]: invoice[item].substring(0, 10) });
+        else // this.setState({ [item]: invoice[item] });
       }
 
       this.logo = this.state.logo;
 
       if (this.logo) {
-        this.setState({ disabled: false })
+        this.setState({ disabled: false });
       }
 
       this.logoRef.current.src = window.URL.createObjectURL(
@@ -148,10 +148,8 @@ class InvoiceForm extends Component {
       errCache.push("Please add at least one item.");
     }
 
-
     const newInvoice = new FormData();
     const unusedData = ["edit", "toDashboard", "errorMessages", "disabled"];
-
 
     newInvoice.append("auth0_userID", this.auth0_userID);
 
@@ -169,7 +167,6 @@ class InvoiceForm extends Component {
       }
     }
 
-    
     this.setState({ errorMessages: errCache });
     if (errCache.length > 0) return null;
     return newInvoice;
@@ -206,15 +203,15 @@ class InvoiceForm extends Component {
 
     const params = this.props.params;
 
-    if(newInvoice){
+    if (newInvoice) {
       axios
-      .put(process.env.REACT_APP_NEW_INVOICE + `/${params.id}`, newInvoice)
-      .then(res => {
-        this.setState({ toDashboard: true });
-      })
-      .catch(err => {
-        console.log("ERROR", err);
-      });
+        .put(process.env.REACT_APP_NEW_INVOICE + `/${params.id}`, newInvoice)
+        .then(res => {
+          this.setState({ toDashboard: true });
+        })
+        .catch(err => {
+          console.log("ERROR", err);
+        });
     }
   };
 
@@ -533,51 +530,51 @@ class InvoiceForm extends Component {
                 Invoice Number
               </Label>
               <Col sm={4}>
-                {this.state.edit ? 
-                <Input
-                  value={this.state.invoice_number}
-                  type="number"
-                  name="invoice_number"
-                  id="invoice_number"
-                  placeholder="Invoice Number"
-                  onChange={this.handleInputChange}
-                  disabled
-                />
-                :
-                <Input
-                  value={this.state.invoice_number}
-                  type="number"
-                  name="invoice_number"
-                  id="invoice_number"
-                  placeholder="Invoice Number"
-                  onChange={this.handleInputChange}
-                />
-                }
+                {this.state.edit ? (
+                  <Input
+                    value={this.state.invoice_number}
+                    type="number"
+                    name="invoice_number"
+                    id="invoice_number"
+                    placeholder="Invoice Number"
+                    onChange={this.handleInputChange}
+                    disabled
+                  />
+                ) : (
+                  <Input
+                    value={this.state.invoice_number}
+                    type="number"
+                    name="invoice_number"
+                    id="invoice_number"
+                    placeholder="Invoice Number"
+                    onChange={this.handleInputChange}
+                  />
+                )}
               </Col>
               <Label for="date" sm={2} className="date-label">
                 Date
               </Label>
               <Col sm={4} className="date">
-                {this.state.edit ?
-                <Input
-                  value={this.state.date}
-                  type="date"
-                  name="date"
-                  id="date"
-                  placeholder="Date"
-                  onChange={this.handleInputChange}
-                  disabled
-                />
-                :
-                <Input
-                  value={this.state.date}
-                  type="date"
-                  name="date"
-                  id="date"
-                  placeholder="Date"
-                  onChange={this.handleInputChange}
-                />
-                }
+                {this.state.edit ? (
+                  <Input
+                    value={this.state.date}
+                    type="date"
+                    name="date"
+                    id="date"
+                    placeholder="Date"
+                    onChange={this.handleInputChange}
+                    disabled
+                  />
+                ) : (
+                  <Input
+                    value={this.state.date}
+                    type="date"
+                    name="date"
+                    id="date"
+                    placeholder="Date"
+                    onChange={this.handleInputChange}
+                  />
+                )}
               </Col>
             </FormGroup>
             {/* Invoice Customer Company Details */}
@@ -591,51 +588,51 @@ class InvoiceForm extends Component {
                 Invoice From
               </Label>
               <Col sm={6} className="invoice-from">
-                {this.state.edit ? 
-                <Input
-                  value={this.state.company_name}
-                  type="text"
-                  name="company_name"
-                  id="company_name"
-                  placeholder="Invoice From"
-                  onChange={this.handleInputChange}
-                  disabled
-                />
-                :
-                <Input
-                  value={this.state.company_name}
-                  type="text"
-                  name="company_name"
-                  id="company_name"
-                  placeholder="Invoice From"
-                  onChange={this.handleInputChange}
-                />
-                }
+                {this.state.edit ? (
+                  <Input
+                    value={this.state.company_name}
+                    type="text"
+                    name="company_name"
+                    id="company_name"
+                    placeholder="Invoice From"
+                    onChange={this.handleInputChange}
+                    disabled
+                  />
+                ) : (
+                  <Input
+                    value={this.state.company_name}
+                    type="text"
+                    name="company_name"
+                    id="company_name"
+                    placeholder="Invoice From"
+                    onChange={this.handleInputChange}
+                  />
+                )}
               </Col>
               <Label for="due_date" sm={2} className="due-date-label">
                 Due Date
               </Label>
               <Col sm={4} className="due-date">
-                {this.state.edit ?
-                <Input
-                  value={this.state.due_date}
-                  type="date"
-                  name="due_date"
-                  id="due_date"
-                  placeholder="Due Date"
-                  onChange={this.handleInputChange}
-                  disabled
-                />
-                :
-                <Input
-                  value={this.state.due_date}
-                  type="date"
-                  name="due_date"
-                  id="due_date"
-                  placeholder="Due Date"
-                  onChange={this.handleInputChange}
-                />
-                }
+                {this.state.edit ? (
+                  <Input
+                    value={this.state.due_date}
+                    type="date"
+                    name="due_date"
+                    id="due_date"
+                    placeholder="Due Date"
+                    onChange={this.handleInputChange}
+                    disabled
+                  />
+                ) : (
+                  <Input
+                    value={this.state.due_date}
+                    type="date"
+                    name="due_date"
+                    id="due_date"
+                    placeholder="Due Date"
+                    onChange={this.handleInputChange}
+                  />
+                )}
               </Col>
             </FormGroup>
             <FormGroup row>
@@ -643,26 +640,26 @@ class InvoiceForm extends Component {
                 Invoice To
               </Label>
               <Col sm={6} className="invoice-to">
-                {this.state.edit ? 
-                <Input
-                  value={this.state.invoiceTo}
-                  type="text"
-                  name="invoiceTo"
-                  id="invoiceTo"
-                  placeholder="Invoice To"
-                  onChange={this.handleInputChange}
-                  disabled
-                />
-                :
-                <Input
-                  value={this.state.invoiceTo}
-                  type="text"
-                  name="invoiceTo"
-                  id="invoiceTo"
-                  placeholder="Invoice To"
-                  onChange={this.handleInputChange}
-                />
-                }
+                {this.state.edit ? (
+                  <Input
+                    value={this.state.invoiceTo}
+                    type="text"
+                    name="invoiceTo"
+                    id="invoiceTo"
+                    placeholder="Invoice To"
+                    onChange={this.handleInputChange}
+                    disabled
+                  />
+                ) : (
+                  <Input
+                    value={this.state.invoiceTo}
+                    type="text"
+                    name="invoiceTo"
+                    id="invoiceTo"
+                    placeholder="Invoice To"
+                    onChange={this.handleInputChange}
+                  />
+                )}
               </Col>
               <Label for="balance_due" sm={2} className="balance-due-label">
                 Balance Due
@@ -682,8 +679,7 @@ class InvoiceForm extends Component {
               <Label for="address" hidden className="address-label">
                 Address
               </Label>
-              {this.state.edit 
-              ?
+              {this.state.edit ? (
                 <Input
                   className="address"
                   value={this.state.address}
@@ -694,7 +690,7 @@ class InvoiceForm extends Component {
                   onChange={this.handleInputChange}
                   disabled
                 />
-              : 
+              ) : (
                 <Input
                   className="address"
                   value={this.state.address}
@@ -704,7 +700,7 @@ class InvoiceForm extends Component {
                   placeholder="Address"
                   onChange={this.handleInputChange}
                 />
-              }
+              )}
             </FormGroup>
             <Row form>
               <Col md={2}>
@@ -712,7 +708,7 @@ class InvoiceForm extends Component {
                   <Label for="zipcode" hidden className="zip-label">
                     Zip
                   </Label>
-                  {this.state.edit ? 
+                  {this.state.edit ? (
                     <Input
                       className="zip"
                       value={this.state.zipcode}
@@ -723,7 +719,7 @@ class InvoiceForm extends Component {
                       onChange={this.handleZipChange}
                       disabled
                     />
-                  : 
+                  ) : (
                     <Input
                       className="zip"
                       value={this.state.zipcode}
@@ -733,7 +729,7 @@ class InvoiceForm extends Component {
                       placeholder="Zip"
                       onChange={this.handleZipChange}
                     />
-                  }
+                  )}
                 </FormGroup>
               </Col>
               <Col md={6}>
@@ -741,7 +737,7 @@ class InvoiceForm extends Component {
                   <Label for="city" hidden className="city-label">
                     City
                   </Label>
-                  {this.state.edit ? 
+                  {this.state.edit ? (
                     <Input
                       className="city"
                       value={this.state.city}
@@ -752,7 +748,7 @@ class InvoiceForm extends Component {
                       onChange={this.handleTaxChange}
                       disabled
                     />
-                  :
+                  ) : (
                     <Input
                       className="city"
                       value={this.state.city}
@@ -762,7 +758,7 @@ class InvoiceForm extends Component {
                       placeholder="City"
                       onChange={this.handleTaxChange}
                     />
-                  }
+                  )}
                 </FormGroup>
               </Col>
               <Col md={4}>
@@ -770,8 +766,7 @@ class InvoiceForm extends Component {
                   <Label for="state" hidden className="state-label">
                     State
                   </Label>
-                  {this.state.edit 
-                  ? 
+                  {this.state.edit ? (
                     <Input
                       className="state"
                       value={this.state.state}
@@ -782,7 +777,7 @@ class InvoiceForm extends Component {
                       onChange={this.handleTaxChange}
                       disabled
                     />
-                  : 
+                  ) : (
                     <Input
                       className="state"
                       value={this.state.state}
@@ -792,7 +787,7 @@ class InvoiceForm extends Component {
                       placeholder="State"
                       onChange={this.handleTaxChange}
                     />
-                  }
+                  )}
                 </FormGroup>
               </Col>
             </Row>
@@ -824,10 +819,11 @@ class InvoiceForm extends Component {
                   })}
                 </tbody>
               </Table>
-            </div> {/* table-outer-container */}
+            </div>{" "}
+            {/* table-outer-container */}
             {/* Add Line Item */}
             <div>
-              {this.state.edit ? 
+              {this.state.edit ? (
                 <Button
                   className="button-line-items"
                   color="secondary"
@@ -835,8 +831,8 @@ class InvoiceForm extends Component {
                   disabled
                 >
                   Add Line Item +
-                </Button> 
-              :
+                </Button>
+              ) : (
                 <Button
                   className="button-line-items"
                   color="secondary"
@@ -844,7 +840,7 @@ class InvoiceForm extends Component {
                 >
                   Add Line Item +
                 </Button>
-              }
+              )}
             </div>
             <FormGroup row>
               <Label for="subtotal" sm={2}>
@@ -867,8 +863,7 @@ class InvoiceForm extends Component {
               </Label>
               <Col sm="2">
                 <InputGroup>
-                  {this.state.edit 
-                  ? 
+                  {this.state.edit ? (
                     <Input
                       value={this.state.discount}
                       type="number"
@@ -880,7 +875,7 @@ class InvoiceForm extends Component {
                       onChange={this.handleInputChange}
                       disabled
                     />
-                  : 
+                  ) : (
                     <Input
                       value={this.state.discount}
                       type="number"
@@ -891,7 +886,7 @@ class InvoiceForm extends Component {
                       placeholder="0"
                       onChange={this.handleInputChange}
                     />
-                  }
+                  )}
                   <InputGroupAddon addonType="append">%</InputGroupAddon>
                 </InputGroup>
               </Col>
@@ -902,8 +897,7 @@ class InvoiceForm extends Component {
               </Label>
               <Col sm="2">
                 <InputGroup>
-                  {this.state.edit 
-                  ? 
+                  {this.state.edit ? (
                     <Input
                       value={parseFloat((this.state.taxRate * 100).toFixed(2))}
                       type="percent"
@@ -912,7 +906,7 @@ class InvoiceForm extends Component {
                       placeholder="0%"
                       disabled
                     />
-                  : 
+                  ) : (
                     <Input
                       value={parseFloat((this.state.taxRate * 100).toFixed(2))}
                       type="percent"
@@ -920,7 +914,7 @@ class InvoiceForm extends Component {
                       id="tax"
                       placeholder="0%"
                     />
-                  }
+                  )}
                   <InputGroupAddon addonType="append">%</InputGroupAddon>
                 </InputGroup>
               </Col>
@@ -933,33 +927,32 @@ class InvoiceForm extends Component {
               <Col sm="3">
                 <InputGroup>
                   <InputGroupAddon addonType="prepend">$</InputGroupAddon>
-                  {this.state.edit
-                  ?
-                  <Input
-                    value={this.state.shipping}
-                    // value={accounting.formatMoney(this.state.shipping)}
-                    type="number" 
-                    min="0" 
-                    max="99999" 
-                    name="shipping"
-                    id="shipping"
-                    placeholder="0.00"
-                    onChange={this.handleInputChange}
-                    disabled
-                  />
-                  :
-                  <Input
-                    value={this.state.shipping}
-                    // value={accounting.formatMoney(this.state.shipping)}
-                    type="number" 
-                    min="0" 
-                    max="99999" 
-                    name="shipping"
-                    id="shipping"
-                    placeholder="0.00"
-                    onChange={this.handleInputChange}
-                  />
-                  }
+                  {this.state.edit ? (
+                    <Input
+                      value={this.state.shipping}
+                      // value={accounting.formatMoney(this.state.shipping)}
+                      type="number"
+                      min="0"
+                      max="99999"
+                      name="shipping"
+                      id="shipping"
+                      placeholder="0.00"
+                      onChange={this.handleInputChange}
+                      disabled
+                    />
+                  ) : (
+                    <Input
+                      value={this.state.shipping}
+                      // value={accounting.formatMoney(this.state.shipping)}
+                      type="number"
+                      min="0"
+                      max="99999"
+                      name="shipping"
+                      id="shipping"
+                      placeholder="0.00"
+                      onChange={this.handleInputChange}
+                    />
+                  )}
                 </InputGroup>
               </Col>
             </FormGroup>
@@ -1014,31 +1007,30 @@ class InvoiceForm extends Component {
               <Label for="terms" className="terms-label">
                 Terms
               </Label>
-              {this.state.edit ? 
-              <Input
-                value={this.state.terms}
-                type="text"
-                name="terms"
-                id="terms"
-                placeholder="Add Terms Here"
-                onChange={this.handleInputChange}
-                disabled
-              />
-              : 
-              <Input
-                value={this.state.terms}
-                type="text"
-                name="terms"
-                id="terms"
-                placeholder="Add Terms Here"
-                onChange={this.handleInputChange}
-              />}
+              {this.state.edit ? (
+                <Input
+                  value={this.state.terms}
+                  type="text"
+                  name="terms"
+                  id="terms"
+                  placeholder="Add Terms Here"
+                  onChange={this.handleInputChange}
+                  disabled
+                />
+              ) : (
+                <Input
+                  value={this.state.terms}
+                  type="text"
+                  name="terms"
+                  id="terms"
+                  placeholder="Add Terms Here"
+                  onChange={this.handleInputChange}
+                />
+              )}
             </FormGroup>
-
             {this.state.errorMessages.map(error => (
               <div className="form-error">{error}</div>
             ))}
-
             {this.state.edit ? (
               <Button
                 type="generate"

--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -34,7 +34,6 @@ class InvoiceForm extends Component {
     this.logo = null;
     this.logoRaw = null;
     this.invalidForm = false;
-    this.edit = false;
     this.logoRef = React.createRef();
   }
   state = {
@@ -76,7 +75,7 @@ class InvoiceForm extends Component {
 
     if (path === "/invoices/:id") {
       const params = this.props.params;
-      this.edit = true;
+      this.state.edit = true;
       const invoice = (await axios.get(
         process.env.REACT_APP_NEW_INVOICE + `/${params.id}`
       )).data;
@@ -517,7 +516,7 @@ class InvoiceForm extends Component {
                 onChange={this.handleImageChange}
                 disabled={this.state.disabled}
               />
-              {this.edit ? (
+              {this.state.edit ? (
                 <FormText color="muted">
                   Browse file to change your company logo.
                 </FormText>
@@ -534,7 +533,7 @@ class InvoiceForm extends Component {
                 Invoice Number
               </Label>
               <Col sm={4}>
-                {this.edit ? 
+                {this.state.edit ? 
                 <Input
                   value={this.state.invoice_number}
                   type="number"
@@ -559,7 +558,7 @@ class InvoiceForm extends Component {
                 Date
               </Label>
               <Col sm={4} className="date">
-                {this.edit ?
+                {this.state.edit ?
                 <Input
                   value={this.state.date}
                   type="date"
@@ -592,7 +591,7 @@ class InvoiceForm extends Component {
                 Invoice From
               </Label>
               <Col sm={6} className="invoice-from">
-                {this.edit ? 
+                {this.state.edit ? 
                 <Input
                   value={this.state.company_name}
                   type="text"
@@ -617,7 +616,7 @@ class InvoiceForm extends Component {
                 Due Date
               </Label>
               <Col sm={4} className="due-date">
-                {this.edit ?
+                {this.state.edit ?
                 <Input
                   value={this.state.due_date}
                   type="date"
@@ -644,7 +643,7 @@ class InvoiceForm extends Component {
                 Invoice To
               </Label>
               <Col sm={6} className="invoice-to">
-                {this.edit ? 
+                {this.state.edit ? 
                 <Input
                   value={this.state.invoiceTo}
                   type="text"
@@ -683,7 +682,7 @@ class InvoiceForm extends Component {
               <Label for="address" hidden className="address-label">
                 Address
               </Label>
-              {this.edit 
+              {this.state.edit 
               ?
                 <Input
                   className="address"
@@ -713,7 +712,7 @@ class InvoiceForm extends Component {
                   <Label for="zipcode" hidden className="zip-label">
                     Zip
                   </Label>
-                  {this.edit ? 
+                  {this.state.edit ? 
                     <Input
                       className="zip"
                       value={this.state.zipcode}
@@ -742,7 +741,7 @@ class InvoiceForm extends Component {
                   <Label for="city" hidden className="city-label">
                     City
                   </Label>
-                  {this.edit ? 
+                  {this.state.edit ? 
                     <Input
                       className="city"
                       value={this.state.city}
@@ -771,7 +770,7 @@ class InvoiceForm extends Component {
                   <Label for="state" hidden className="state-label">
                     State
                   </Label>
-                  {this.edit 
+                  {this.state.edit 
                   ? 
                     <Input
                       className="state"
@@ -819,7 +818,7 @@ class InvoiceForm extends Component {
                         quantity={row.quantity}
                         rate={row.rate}
                         handleLineItemChange={this.handleLineItemChange}
-                        edit={this.edit}
+                        edit={this.state.edit}
                       />
                     );
                   })}
@@ -828,7 +827,7 @@ class InvoiceForm extends Component {
             </div> {/* table-outer-container */}
             {/* Add Line Item */}
             <div>
-              {this.edit ? 
+              {this.state.edit ? 
                 <Button
                   className="button-line-items"
                   color="secondary"
@@ -868,7 +867,7 @@ class InvoiceForm extends Component {
               </Label>
               <Col sm="2">
                 <InputGroup>
-                  {this.edit 
+                  {this.state.edit 
                   ? 
                     <Input
                       value={this.state.discount}
@@ -903,7 +902,7 @@ class InvoiceForm extends Component {
               </Label>
               <Col sm="2">
                 <InputGroup>
-                  {this.edit 
+                  {this.state.edit 
                   ? 
                     <Input
                       value={parseFloat((this.state.taxRate * 100).toFixed(2))}
@@ -934,7 +933,7 @@ class InvoiceForm extends Component {
               <Col sm="3">
                 <InputGroup>
                   <InputGroupAddon addonType="prepend">$</InputGroupAddon>
-                  {this.edit
+                  {this.state.edit
                   ?
                   <Input
                     value={this.state.shipping}
@@ -1015,7 +1014,7 @@ class InvoiceForm extends Component {
               <Label for="terms" className="terms-label">
                 Terms
               </Label>
-              {this.edit ? 
+              {this.state.edit ? 
               <Input
                 value={this.state.terms}
                 type="text"
@@ -1040,7 +1039,7 @@ class InvoiceForm extends Component {
               <div className="form-error">{error}</div>
             ))}
 
-            {this.edit ? (
+            {this.state.edit ? (
               <Button
                 type="generate"
                 className="update-button"

--- a/client/src/Components/InvoiceForm/InvoiceForm.js
+++ b/client/src/Components/InvoiceForm/InvoiceForm.js
@@ -528,12 +528,23 @@ class InvoiceForm extends Component {
               )}
             </FormGroup>
             <img ref={this.logoRef} className="logo-img" />
-            {/* Invoice Header Rigth Side */}
+            {/* Invoice Header Right Side */}
             <FormGroup row className="invoice-number">
               <Label for="invoice_number" sm={2}>
                 Invoice Number
               </Label>
               <Col sm={4}>
+                {this.edit ? 
+                <Input
+                  value={this.state.invoice_number}
+                  type="number"
+                  name="invoice_number"
+                  id="invoice_number"
+                  placeholder="Invoice Number"
+                  onChange={this.handleInputChange}
+                  disabled
+                />
+                :
                 <Input
                   value={this.state.invoice_number}
                   type="number"
@@ -542,11 +553,23 @@ class InvoiceForm extends Component {
                   placeholder="Invoice Number"
                   onChange={this.handleInputChange}
                 />
+                }
               </Col>
               <Label for="date" sm={2} className="date-label">
                 Date
               </Label>
               <Col sm={4} className="date">
+                {this.edit ?
+                <Input
+                  value={this.state.date}
+                  type="date"
+                  name="date"
+                  id="date"
+                  placeholder="Date"
+                  onChange={this.handleInputChange}
+                  disabled
+                />
+                :
                 <Input
                   value={this.state.date}
                   type="date"
@@ -555,6 +578,7 @@ class InvoiceForm extends Component {
                   placeholder="Date"
                   onChange={this.handleInputChange}
                 />
+                }
               </Col>
             </FormGroup>
             {/* Invoice Customer Company Details */}
@@ -568,6 +592,17 @@ class InvoiceForm extends Component {
                 Invoice From
               </Label>
               <Col sm={6} className="invoice-from">
+                {this.edit ? 
+                <Input
+                  value={this.state.company_name}
+                  type="text"
+                  name="company_name"
+                  id="company_name"
+                  placeholder="Invoice From"
+                  onChange={this.handleInputChange}
+                  disabled
+                />
+                :
                 <Input
                   value={this.state.company_name}
                   type="text"
@@ -576,11 +611,23 @@ class InvoiceForm extends Component {
                   placeholder="Invoice From"
                   onChange={this.handleInputChange}
                 />
+                }
               </Col>
               <Label for="due_date" sm={2} className="due-date-label">
                 Due Date
               </Label>
               <Col sm={4} className="due-date">
+                {this.edit ?
+                <Input
+                  value={this.state.due_date}
+                  type="date"
+                  name="due_date"
+                  id="due_date"
+                  placeholder="Due Date"
+                  onChange={this.handleInputChange}
+                  disabled
+                />
+                :
                 <Input
                   value={this.state.due_date}
                   type="date"
@@ -589,6 +636,7 @@ class InvoiceForm extends Component {
                   placeholder="Due Date"
                   onChange={this.handleInputChange}
                 />
+                }
               </Col>
             </FormGroup>
             <FormGroup row>
@@ -596,6 +644,17 @@ class InvoiceForm extends Component {
                 Invoice To
               </Label>
               <Col sm={6} className="invoice-to">
+                {this.edit ? 
+                <Input
+                  value={this.state.invoiceTo}
+                  type="text"
+                  name="invoiceTo"
+                  id="invoiceTo"
+                  placeholder="Invoice To"
+                  onChange={this.handleInputChange}
+                  disabled
+                />
+                :
                 <Input
                   value={this.state.invoiceTo}
                   type="text"
@@ -604,6 +663,7 @@ class InvoiceForm extends Component {
                   placeholder="Invoice To"
                   onChange={this.handleInputChange}
                 />
+                }
               </Col>
               <Label for="balance_due" sm={2} className="balance-due-label">
                 Balance Due
@@ -623,15 +683,29 @@ class InvoiceForm extends Component {
               <Label for="address" hidden className="address-label">
                 Address
               </Label>
-              <Input
-                className="address"
-                value={this.state.address}
-                type="text"
-                name="address"
-                id="address"
-                placeholder="Address"
-                onChange={this.handleInputChange}
-              />
+              {this.edit 
+              ?
+                <Input
+                  className="address"
+                  value={this.state.address}
+                  type="text"
+                  name="address"
+                  id="address"
+                  placeholder="Address"
+                  onChange={this.handleInputChange}
+                  disabled
+                />
+              : 
+                <Input
+                  className="address"
+                  value={this.state.address}
+                  type="text"
+                  name="address"
+                  id="address"
+                  placeholder="Address"
+                  onChange={this.handleInputChange}
+                />
+              }
             </FormGroup>
             <Row form>
               <Col md={2}>
@@ -639,15 +713,28 @@ class InvoiceForm extends Component {
                   <Label for="zipcode" hidden className="zip-label">
                     Zip
                   </Label>
-                  <Input
-                    className="zip"
-                    value={this.state.zipcode}
-                    type="text"
-                    name="zipcode"
-                    id="zipcode"
-                    placeholder="Zip"
-                    onChange={this.handleZipChange}
-                  />
+                  {this.edit ? 
+                    <Input
+                      className="zip"
+                      value={this.state.zipcode}
+                      type="text"
+                      name="zipcode"
+                      id="zipcode"
+                      placeholder="Zip"
+                      onChange={this.handleZipChange}
+                      disabled
+                    />
+                  : 
+                    <Input
+                      className="zip"
+                      value={this.state.zipcode}
+                      type="text"
+                      name="zipcode"
+                      id="zipcode"
+                      placeholder="Zip"
+                      onChange={this.handleZipChange}
+                    />
+                  }
                 </FormGroup>
               </Col>
               <Col md={6}>
@@ -655,15 +742,28 @@ class InvoiceForm extends Component {
                   <Label for="city" hidden className="city-label">
                     City
                   </Label>
-                  <Input
-                    className="city"
-                    value={this.state.city}
-                    type="text"
-                    name="city"
-                    id="city"
-                    placeholder="City"
-                    onChange={this.handleTaxChange}
-                  />
+                  {this.edit ? 
+                    <Input
+                      className="city"
+                      value={this.state.city}
+                      type="text"
+                      name="city"
+                      id="city"
+                      placeholder="City"
+                      onChange={this.handleTaxChange}
+                      disabled
+                    />
+                  :
+                    <Input
+                      className="city"
+                      value={this.state.city}
+                      type="text"
+                      name="city"
+                      id="city"
+                      placeholder="City"
+                      onChange={this.handleTaxChange}
+                    />
+                  }
                 </FormGroup>
               </Col>
               <Col md={4}>
@@ -671,15 +771,29 @@ class InvoiceForm extends Component {
                   <Label for="state" hidden className="state-label">
                     State
                   </Label>
-                  <Input
-                    className="state"
-                    value={this.state.state}
-                    type="text"
-                    name="state"
-                    id="state"
-                    placeholder="State"
-                    onChange={this.handleTaxChange}
-                  />
+                  {this.edit 
+                  ? 
+                    <Input
+                      className="state"
+                      value={this.state.state}
+                      type="text"
+                      name="state"
+                      id="state"
+                      placeholder="State"
+                      onChange={this.handleTaxChange}
+                      disabled
+                    />
+                  : 
+                    <Input
+                      className="state"
+                      value={this.state.state}
+                      type="text"
+                      name="state"
+                      id="state"
+                      placeholder="State"
+                      onChange={this.handleTaxChange}
+                    />
+                  }
                 </FormGroup>
               </Col>
             </Row>
@@ -705,6 +819,7 @@ class InvoiceForm extends Component {
                         quantity={row.quantity}
                         rate={row.rate}
                         handleLineItemChange={this.handleLineItemChange}
+                        edit={this.edit}
                       />
                     );
                   })}
@@ -713,13 +828,24 @@ class InvoiceForm extends Component {
             </div> {/* table-outer-container */}
             {/* Add Line Item */}
             <div>
-              <Button
-                className="button-line-items"
-                color="secondary"
-                onClick={this.addLineItem}
-              >
-                Add Line Item +
-              </Button>
+              {this.edit ? 
+                <Button
+                  className="button-line-items"
+                  color="secondary"
+                  onClick={this.addLineItem}
+                  disabled
+                >
+                  Add Line Item +
+                </Button> 
+              :
+                <Button
+                  className="button-line-items"
+                  color="secondary"
+                  onClick={this.addLineItem}
+                >
+                  Add Line Item +
+                </Button>
+              }
             </div>
             <FormGroup row>
               <Label for="subtotal" sm={2}>
@@ -742,16 +868,31 @@ class InvoiceForm extends Component {
               </Label>
               <Col sm="2">
                 <InputGroup>
-                  <Input
-                    value={this.state.discount}
-                    type="number"
-                    min="0"
-                    max="100"
-                    name="discount"
-                    id="discount"
-                    placeholder="0"
-                    onChange={this.handleInputChange}
-                  />
+                  {this.edit 
+                  ? 
+                    <Input
+                      value={this.state.discount}
+                      type="number"
+                      min="0"
+                      max="100"
+                      name="discount"
+                      id="discount"
+                      placeholder="0"
+                      onChange={this.handleInputChange}
+                      disabled
+                    />
+                  : 
+                    <Input
+                      value={this.state.discount}
+                      type="number"
+                      min="0"
+                      max="100"
+                      name="discount"
+                      id="discount"
+                      placeholder="0"
+                      onChange={this.handleInputChange}
+                    />
+                  }
                   <InputGroupAddon addonType="append">%</InputGroupAddon>
                 </InputGroup>
               </Col>
@@ -762,13 +903,25 @@ class InvoiceForm extends Component {
               </Label>
               <Col sm="2">
                 <InputGroup>
-                  <Input
-                    value={parseFloat((this.state.taxRate * 100).toFixed(2))}
-                    type="percent"
-                    name="tax"
-                    id="tax"
-                    placeholder="0%"
-                  />
+                  {this.edit 
+                  ? 
+                    <Input
+                      value={parseFloat((this.state.taxRate * 100).toFixed(2))}
+                      type="percent"
+                      name="tax"
+                      id="tax"
+                      placeholder="0%"
+                      disabled
+                    />
+                  : 
+                    <Input
+                      value={parseFloat((this.state.taxRate * 100).toFixed(2))}
+                      type="percent"
+                      name="tax"
+                      id="tax"
+                      placeholder="0%"
+                    />
+                  }
                   <InputGroupAddon addonType="append">%</InputGroupAddon>
                 </InputGroup>
               </Col>
@@ -781,6 +934,21 @@ class InvoiceForm extends Component {
               <Col sm="3">
                 <InputGroup>
                   <InputGroupAddon addonType="prepend">$</InputGroupAddon>
+                  {this.edit
+                  ?
+                  <Input
+                    value={this.state.shipping}
+                    // value={accounting.formatMoney(this.state.shipping)}
+                    type="number" 
+                    min="0" 
+                    max="99999" 
+                    name="shipping"
+                    id="shipping"
+                    placeholder="0.00"
+                    onChange={this.handleInputChange}
+                    disabled
+                  />
+                  :
                   <Input
                     value={this.state.shipping}
                     // value={accounting.formatMoney(this.state.shipping)}
@@ -792,6 +960,7 @@ class InvoiceForm extends Component {
                     placeholder="0.00"
                     onChange={this.handleInputChange}
                   />
+                  }
                 </InputGroup>
               </Col>
             </FormGroup>
@@ -846,6 +1015,7 @@ class InvoiceForm extends Component {
               <Label for="terms" className="terms-label">
                 Terms
               </Label>
+              {this.edit ? 
               <Input
                 value={this.state.terms}
                 type="text"
@@ -853,7 +1023,17 @@ class InvoiceForm extends Component {
                 id="terms"
                 placeholder="Add Terms Here"
                 onChange={this.handleInputChange}
+                disabled
               />
+              : 
+              <Input
+                value={this.state.terms}
+                type="text"
+                name="terms"
+                id="terms"
+                placeholder="Add Terms Here"
+                onChange={this.handleInputChange}
+              />}
             </FormGroup>
 
             {this.state.errorMessages.map(error => (

--- a/client/src/Components/InvoiceForm/LineItems/LineItems.js
+++ b/client/src/Components/InvoiceForm/LineItems/LineItems.js
@@ -9,42 +9,86 @@ const LineItems = props => {
     <tr className="table_row">
       <th scope="row" className="table_header">{props.rowNumber}</th>
       <td>
-        <Input
-          value={props.item}
-          type="text"
-          name="item"
-          id="item"
-          placeholder="Add Item Here"
-          onChange={e => {
-            props.handleLineItemChange(e, props.rowNumber - 1, "item");
-          }}
-        />
+        {props.edit 
+        ?
+          <Input
+            value={props.item}
+            type="text"
+            name="item"
+            id="item"
+            placeholder="No item"
+            onChange={e => {
+              props.handleLineItemChange(e, props.rowNumber - 1, "item");
+            }}
+            disabled
+          /> 
+        :
+          <Input
+            value={props.item}
+            type="text"
+            name="item"
+            id="item"
+            placeholder="Add Item Here"
+            onChange={e => {
+              props.handleLineItemChange(e, props.rowNumber - 1, "item");
+            }}
+          /> 
+        }
       </td>
       <td>
-        <Input
-          value={props.quantity}
-          type="number"
-          name="quantity"
-          id="quantity"
-          placeholder="1"
-          onChange={e => {
-            props.handleLineItemChange(e, props.rowNumber - 1, "quantity");
-          }}
-        />
+        {props.edit 
+        ?
+          <Input
+            value={props.quantity}
+            type="number"
+            name="quantity"
+            id="quantity"
+            placeholder="1"
+            onChange={e => {
+              props.handleLineItemChange(e, props.rowNumber - 1, "quantity");
+            }}
+            disabled
+          />
+        : 
+          <Input
+            value={props.quantity}
+            type="number"
+            name="quantity"
+            id="quantity"
+            placeholder="1"
+            onChange={e => {
+              props.handleLineItemChange(e, props.rowNumber - 1, "quantity");
+            }}
+          />
+        }
       </td>
       <td>
         <InputGroup>
           <InputGroupAddon addonType="prepend">$</InputGroupAddon>
-          <Input
-            value={props.rate}
-            type="number"
-            name="rate"
-            id="rate"
-            placeholder="$ 0.00"
-            onChange={e => {
-              props.handleLineItemChange(e, props.rowNumber - 1, "rate");
-            }}
-          />
+          {props.edit ?
+            <Input
+              value={props.rate}
+              type="number"
+              name="rate"
+              id="rate"
+              placeholder="$ 0.00"
+              onChange={e => {
+                props.handleLineItemChange(e, props.rowNumber - 1, "rate");
+              }}
+              disabled
+            />
+          : 
+            <Input
+                value={props.rate}
+                type="number"
+                name="rate"
+                id="rate"
+                placeholder="$ 0.00"
+                onChange={e => {
+                  props.handleLineItemChange(e, props.rowNumber - 1, "rate");
+                }}
+            />
+          }
         </InputGroup>
       </td>
       <td className="row_amount"> 


### PR DESCRIPTION
# Description
checks for edit on invoiceform to indicate whether or not the fields should be editable on update

Fixes # (issue)
https://trello.com/c/DIg2SSke/139-lock-fields-on-invoice-which-dont-make-sense-for-user-to-change

![image](https://user-images.githubusercontent.com/38544354/49898936-50a5f300-fe28-11e8-8651-3084834d0624.png)

nearly everything except for logo, amount paid, and notes are disabled on the update form, now

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Change status
- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [X] Tested in browser

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
